### PR TITLE
Physical node connection fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>7.0.0</version>
+            <version>8.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/rationaleemotions/internal/ProxiedTestSlot.java
+++ b/src/main/java/com/rationaleemotions/internal/ProxiedTestSlot.java
@@ -29,13 +29,10 @@ public class ProxiedTestSlot extends TestSlot {
             if (isRemoteURLSet) {
                 throw new GridException("Configuration error for the node." + u + " isn't a valid URL");
             }
+            else {
+				return super.getRemoteURL();
+			}          
         }
-        return null;
-    }
-
-    @Override
-    public boolean matches(Map<String, Object> desiredCapabilities) {
-        return true;
     }
 
     public void setRemoteURL(URL remoteURL) {

--- a/src/main/java/com/rationaleemotions/proxy/GhostProxy.java
+++ b/src/main/java/com/rationaleemotions/proxy/GhostProxy.java
@@ -77,20 +77,12 @@ public class GhostProxy extends DefaultRemoteProxy {
     @Override
     public void beforeCommand(TestSession session, HttpServletRequest request, HttpServletResponse response) {
         RequestType type = identifyRequestType(request);
-        if (type == START_SESSION) {
-            try {
+        if (type == START_SESSION) {           
                 if (processTestSession(session)) {
                     startServerForTestSession(session);
                 } else {
-                    String msg = "Missing target mapping. Available mappings are " +
-                        ConfigReader.getInstance().getMapping();
-                    throw new IllegalStateException(msg);
-                }
-            } catch (Exception e) {
-                getRegistry().terminate(session, SessionTerminationReason.CREATIONFAILED);
-                LOG.severe("Failed creating a session. Root cause :" + e.getMessage());
-                throw e;
-            }
+                	LOG.info("Missing target mapping. Available mappings are: " + ConfigReader.getInstance().getMapping());
+                }           
         }
         super.beforeCommand(session, request, response);
     }
@@ -100,10 +92,13 @@ public class GhostProxy extends DefaultRemoteProxy {
         super.afterCommand(session, request, response);
         RequestType type = identifyRequestType(request);
         if (type == STOP_SESSION) {
-            stopServerForTestSession(session);
-            if (LOG.isLoggable(Level.INFO)) {
-                LOG.info(String.format("Counter value after decrementing : %d", counter.decrementAndGet()));
-            }
+        	if (processTestSession(session)) {
+				stopServerForTestSession(session);
+				 if (LOG.isLoggable(Level.INFO)) {
+		                LOG.info(String.format("Counter value after decrementing : %d", counter.decrementAndGet()));
+		            }
+			}
+           
         }
     }
 


### PR DESCRIPTION
This pull request allows to connect physical node to just-ask Grid HUB. 
Closes #13
Also updated the spotify Java package 

If user connects physical node that is not specified in  just-ask configuration json, the test session will be assigned to that node
If user connects physical node that duplicates just-ask configuration json, HUB will bounce the test session between docker and physical node.

