### PR TITLE
Ability to set environmental variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ you download the uber jar i.e., the jar name that ends with `jar-with-dependenci
       "target": "selenium/standalone-firefox:3.14.0",
       "implementation": "com.rationaleemotions.server.JvmBasedSeleniumServer"
     }
-  ]
+  ],
+  "environment": {
+     "SCREEN_WIDTH": 1280,
+     "SCREEN_HEIGHT": 720
+  }
 }
 ```
 * Start the On-demand Grid using the below command (Here the JVM argument `-Dconfig.file` is used to specify the 
@@ -90,6 +94,7 @@ after which new test session requests will be queued.
 represents the name of the docker image that is capable of supporting the respective `browser`. The `target` may not 
 be relevant to all `implementation` values (for e.g., the `target` is currently relevant ONLY for `docker` based 
 on-demand nodes.)
+* `environment` - Represents environmental variable key-value pairs to be passed to docker container
 
 ### Understanding the relevance of `implementation`
 **just-ask** currently supports two implementation flavors :

--- a/src/main/java/com/rationaleemotions/config/ConfigReader.java
+++ b/src/main/java/com/rationaleemotions/config/ConfigReader.java
@@ -66,6 +66,16 @@ public class ConfigReader {
         }
         return configuration.getDockerImagePort();
     }
+    
+    /**
+     * @return - The environmental variables to pass to container
+     */
+    public Map<String, String> getEnvironment() {
+        if (configuration == null) {
+            return null;
+        }        
+        return configuration.getEnvironment();
+    }
 
     /**
      * @return - The browser to target (target could for e.g., be docker image) mapping.
@@ -77,7 +87,7 @@ public class ConfigReader {
         }
         return mapping;
     }
-
+    
     /**
      * @return - How many number of sessions are to be honoured at any given point in time.
      * This kind of resembles the threshold value after which new session requests would be put into the
@@ -131,6 +141,7 @@ public class ConfigReader {
         private String dockerImagePort;
         private int maxSession;
         private List<MappingInfo> mapping;
+        private Map<String, String> environment;
 
         public String getDockerRestApiUri() {
             return dockerRestApiUri;
@@ -151,6 +162,10 @@ public class ConfigReader {
         public List<MappingInfo> getMapping() {
             return mapping;
         }
+        
+        public Map<String, String> getEnvironment() {	
+            return environment;
+        }
 
         @Override
         public String toString() {
@@ -159,6 +174,7 @@ public class ConfigReader {
                 ", localhost='" + localhost + '\'' +
                 ", dockerImagePort='" + dockerImagePort + '\'' +
                 ", maxSession=" + maxSession +
+                ", environment=" + environment +
                 ", mapping=" + mapping +
                 '}';
         }

--- a/src/main/java/com/rationaleemotions/proxy/GhostProxy.java
+++ b/src/main/java/com/rationaleemotions/proxy/GhostProxy.java
@@ -32,7 +32,7 @@ import static org.openqa.grid.web.servlet.handler.RequestType.STOP_SESSION;
  * and then routing the session traffic to the spawned server.
  */
 public class GhostProxy extends DefaultRemoteProxy {
-    private final AtomicInteger counter = new AtomicInteger(1);
+    private final AtomicInteger counter = new AtomicInteger(0);
 
 
     private interface Marker {

--- a/src/main/java/com/rationaleemotions/server/DockerHelper.java
+++ b/src/main/java/com/rationaleemotions/server/DockerHelper.java
@@ -103,10 +103,20 @@ class DockerHelper {
         }
 
         final HostConfig hostConfig = hostConfigBuilder.build();
-
+        
+        // add environmental variables
+        List<String> envVariables = new ArrayList<>();
+        
+        Map<String, String> map = ConfigReader.getInstance().getEnvironment();
+        if (!map.isEmpty()) {
+        	for (Map.Entry<String, String> entry : map.entrySet()) {
+    			envVariables.add(entry.getKey() + "=" + entry.getValue());
+    		}       	        	
+		}
+        		
         final ContainerConfig containerConfig = ContainerConfig.builder()
             .hostConfig(hostConfig)
-            .image(image).exposedPorts(ConfigReader.getInstance().getDockerImagePort())
+            .image(image).exposedPorts(ConfigReader.getInstance().getDockerImagePort()).env(envVariables)
             .build();
 
         final ContainerCreation creation = getClient().createContainer(containerConfig);
@@ -122,7 +132,7 @@ class DockerHelper {
             LOG.fine(msg);
         }
 
-        if (! containerInfo.state().running()) {
+        if (!containerInfo.state().running()) {
             // Start container
             getClient().startContainer(id);
             if (LOG.isLoggable(Level.FINE)) {


### PR DESCRIPTION
References #14 
This pull request allows to pass environmental variables via key _environment_  in json configuration file
This makes key _environment_ mandatory, eg:
```json
{
  "dockerRestApiUri": "http://localhost:2375",
  "localhost": "0.0.0.0",
  "dockerImagePort": "4444",
  "maxSession": 10,
  "mapping": [
    {
      "browser": "chrome",
      "target": "selenium/standalone-chrome:latest",
      "implementation": "com.rationaleemotions.server.DockerBasedSeleniumServer"
    },
    {
      "browser": "firefox",
      "target": "selenium/standalone-firefox-debug:latest",
      "implementation": "com.rationaleemotions.server.DockerBasedSeleniumServer"
    }
  ],
  "environment": {
     "SCREEN_WIDTH": 768,
     "SCREEN_HEIGHT": 24
  }
}
```
Or it can be left empty eg:
```json
"environment": {
}
```
If approved, the readme should be updated as well with new json key

Also changed session counter to start from 0