### PR TITLE
Capability matching fix

### DIFF
--- a/src/main/java/com/rationaleemotions/proxy/GhostProxy.java
+++ b/src/main/java/com/rationaleemotions/proxy/GhostProxy.java
@@ -53,15 +53,19 @@ public class GhostProxy extends DefaultRemoteProxy {
 
     @Override
     public TestSession getNewSession(Map<String, Object> requestedCapability) {
+    	if (LOG.isLoggable(Level.FINE)) {
+            LOG.fine(String.format("Trying to create a new session on node %s", this));
+        }
+    	
+    	if (!hasCapability(requestedCapability)) {
+    		LOG.fine("Node " + this + " has no matching capability");
+    	      return null;
+    	    }
 
         if (counter.get() > ConfigReader.getInstance().getMaxSession()) {
             LOG.info("Waiting for remote nodes to be available");
             return null;
-        }
-
-        if (LOG.isLoggable(Level.FINE)) {
-            LOG.fine(String.format("Trying to create a new session on node %s", this));
-        }
+        }        
 
         // any slot left for the given app ?
         for (TestSlot testslot : getTestSlots()) {
@@ -114,11 +118,6 @@ public class GhostProxy extends DefaultRemoteProxy {
         	    }
         	}
         }
-    }
-
-    @Override
-    public boolean hasCapability(Map<String, Object> requestedCapability) {
-        return true;
     }
 
     @Override


### PR DESCRIPTION
This fixes capability matching issue where capabilities where not checked, they always returned true.
In that way new session with incorrect capabilities where put in Grid queue.
Now if wrong capabilities are set, Grid will throw a good original exception and will not put a session in queue, e.g.:
Error forwarding the new session cannot find : Capabilities 