### PR TITLE
capability match fix in GhostProxy

### DIFF
--- a/src/main/java/com/rationaleemotions/proxy/GhostProxy.java
+++ b/src/main/java/com/rationaleemotions/proxy/GhostProxy.java
@@ -53,14 +53,17 @@ public class GhostProxy extends DefaultRemoteProxy {
 
     @Override
     public TestSession getNewSession(Map<String, Object> requestedCapability) {
+    	
+    	 LOG.fine(String.format("Trying to create a new session on node %s", this));
+
+        if (!hasCapability(requestedCapability)) {
+        	LOG.fine("Node " + this + " has no matching capability");
+          return null;
+        }
 
         if (counter.get() > ConfigReader.getInstance().getMaxSession()) {
             LOG.info("Waiting for remote nodes to be available");
             return null;
-        }
-
-        if (LOG.isLoggable(Level.FINE)) {
-            LOG.fine(String.format("Trying to create a new session on node %s", this));
         }
 
         // any slot left for the given app ?
@@ -114,11 +117,6 @@ public class GhostProxy extends DefaultRemoteProxy {
         	    }
         	}
         }
-    }
-
-    @Override
-    public boolean hasCapability(Map<String, Object> requestedCapability) {
-        return true;
     }
 
     @Override


### PR DESCRIPTION
Closes #22 
Removed `hasCapability` override to use default Selenium.
Added capability check in `getNewSession`.
Now if Grid does not have the passed capability, it will break the session and throw a correct error in Grid HUB console (the default Selenium one) instead putting session in queue.
Tested, this does not break on demand Grid node features.